### PR TITLE
DO-504 Drone ify sbt

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,58 @@
+---
+kind: pipeline
+type: docker
+name: run-checks
+trigger:
+  event:
+    - push
+
+## The Workers's docker socket so our docker runner can run builds from there.
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+steps:
+  # Build the docker image
+  - name: build-docker-image
+    image: docker:18
+    volumes:
+      - name: docker
+        path: '/var/run/docker.sock'
+    commands:
+      - docker build -t sbt:${DRONE_COMMIT_SHA} .
+
+  # Publish docker image for any builds on master
+  - name: publish-ecr
+    image: plugins/ecr:1.0
+    when:
+      branch:
+        - master
+        - main
+    volumes:
+      - name: docker
+        path: '/var/run/docker.sock'
+    settings:
+      access_key:
+        from_secret: AWS_ECR_ACCESS_KEY
+      secret_key:
+        from_secret: AWS_ECR_SECRET_KEY
+      region: us-west-2
+      repo: 878256633362.dkr.ecr.us-west-2.amazonaws.com/sbt
+      tags:
+        - latest
+        - ${DRONE_COMMIT_SHA}
+
+  # Remove the docker image when not master
+  - name: delete-docker-image
+    image: docker:18
+    volumes:
+      - name: docker
+        path: '/var/run/docker.sock'
+    when:
+      branch:
+        exclude: [master, main]
+      status: [success, failure]
+    commands:
+      # Delete the image on a best-effort basis, by always returning 0.
+      - docker rmi sbt:${DRONE_COMMIT_SHA} || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 # This Dockerfile has two required ARGs to determine which base image
 # to use for the JDK and which sbt version to install.
 
-ARG OPENJDK_TAG=8u232
+ARG OPENJDK_TAG=11-jdk-slim
 FROM openjdk:${OPENJDK_TAG}
 
-ARG SBT_VERSION=1.4.9
+ARG SBT_VERSION=1.5.4
 
 # Install sbt
 RUN \
+  apt-get update && \
+  apt-get install -y curl && \
   mkdir /working/ && \
   cd /working/ && \
   curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
   apt-get install sbt && \
   cd && \
   rm -r /working/ && \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # docker-sbt
+
 Dockerfile for sbt (Scala build tool)
 
 This is built on top of the
 [openjdk](https://hub.docker.com/_/openjdk/) image
 and takes inspiration from
 [hseeberger/scala-sbt](https://github.com/hseeberger/scala-sbt).
+
+# Tatari Fork
+
+This fork slightly modifies the Dockerfile to install curl.
+
+This way, we can use a `slim` OpenJDK base for smaller images.
+
+### TODO: 
+It also adds a `.drone.yml` to build and upload to our ECR.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This fork slightly modifies the Dockerfile to install curl.
 
 This way, we can use a `slim` OpenJDK base for smaller images.
 
-### TODO: 
 It also adds a `.drone.yml` to build and upload to our ECR.
 
 ## Usage


### PR DESCRIPTION
This forks the `mozilla/sbt` repo to build an image with the scala build tool that we use as a base in our Spark infrastructure, and in building `flex-aggregator`.

Adds a `.drone.yml` to publish to ECR on merges to master.